### PR TITLE
No cast SampleInterfaces BuildContext::doStopTimer

### DIFF
--- a/RecastDemo/Source/SampleInterfaces.cpp
+++ b/RecastDemo/Source/SampleInterfaces.cpp
@@ -68,7 +68,7 @@ void BuildContext::doStartTimer(const rcTimerLabel label)
 void BuildContext::doStopTimer(const rcTimerLabel label)
 {
 	const TimeVal endTime = getPerfTime();
-	const int deltaTime = (endTime - m_startTime[label]);
+	const TimeVal deltaTime = endTime - m_startTime[label];
 	if (m_accTime[label] == -1)
 		m_accTime[label] = deltaTime;
 	else

--- a/RecastDemo/Source/SampleInterfaces.cpp
+++ b/RecastDemo/Source/SampleInterfaces.cpp
@@ -68,7 +68,7 @@ void BuildContext::doStartTimer(const rcTimerLabel label)
 void BuildContext::doStopTimer(const rcTimerLabel label)
 {
 	const TimeVal endTime = getPerfTime();
-	const int deltaTime = (int)(endTime - m_startTime[label]);
+	const int deltaTime = (endTime - m_startTime[label]);
 	if (m_accTime[label] == -1)
 		m_accTime[label] = deltaTime;
 	else


### PR DESCRIPTION
Removed int cast because it led to loss of time data.
Also removed the () and put TimeVal datatype.

fixes #289